### PR TITLE
Change interfaces name to dllearner-interfaces

### DIFF
--- a/interfaces/pom.xml
+++ b/interfaces/pom.xml
@@ -5,8 +5,9 @@
 
 	<artifactId>interfaces</artifactId>
 	<packaging>${packaging.type}</packaging>
-	<name>Interfaces: GUI, CLI, Web Service</name>
+	<name>dllearner-interfaces</name>
 	<url>http://aksw.org/Projects/DLLearner</url>
+	<description>Interfaces: GUI, CLI, Web Service</description>
 
 
 	<parent>


### PR DESCRIPTION
The content of the name tag was moved to the description.

This was required as RPM files mat not have spaces in their names and the name tag is used as name for the RPM file.