### PR TITLE
Fix SimpleSubclassLearner SPARQL query

### DIFF
--- a/components-core/src/main/java/org/dllearner/algorithms/SimpleSubclassLearner.java
+++ b/components-core/src/main/java/org/dllearner/algorithms/SimpleSubclassLearner.java
@@ -100,7 +100,7 @@ public class SimpleSubclassLearner extends AbstractAxiomLearningAlgorithm<OWLSub
 	 */
 	@Override
 	protected ParameterizedSparqlString getSampleQuery() {
-		return new ParameterizedSparqlString("CONSTRUCT{?s a ?entity . ?s a ?cls1 .} WHERE {?s a ?entity . OPTIONAL {?s a ?cls1 . }");
+		return new ParameterizedSparqlString("CONSTRUCT{?s a ?entity . ?s a ?cls1 .} WHERE {?s a ?entity . OPTIONAL {?s a ?cls1 . }}");
 	}
 
 	/*


### PR DESCRIPTION
I ran into a misformed SPARQL CONSTRUCT query and confirmed it on the SPARQL endpoint I was using in my test that it was indeed wrong. Adding the `}` fixed the query. I haven't checked that it works from within DL-Learner, as using the build script required me to install LaTeX.